### PR TITLE
Fix build errors in openSUSE Tumbleweed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ ALL+= termhelper
 endif
 
 ifeq ($(MAKECMDGOALS),libblastem.$(SO))
-CFLAGS+= -fpic -DIS_LIB
+CFLAGS+= -fcommon -fpic -DIS_LIB
 endif
 
 all : $(ALL)


### PR DESCRIPTION
Fix #13 

The default GCC flags in openSUSE Tumbleweed changed from `-fcommon` to `-fno-common`. So we have to add this flag manually.