### PR TITLE
Make retro_unserialize() return a success

### DIFF
--- a/libblastem.c
+++ b/libblastem.c
@@ -212,7 +212,7 @@ RETRO_API bool retro_serialize(void *data, size_t size)
 RETRO_API bool retro_unserialize(const void *data, size_t size)
 {
 	current_system->deserialize(current_system, (uint8_t *)data, size);
-	return 0;
+	return 1;
 }
 
 RETRO_API void retro_cheat_reset(void)


### PR DESCRIPTION
This helps the frontends know it actually works.

This fixes this snapshot error in GNOME Games: https://gitlab.gnome.org/GNOME/gnome-games/-/merge_requests/453