### PR TITLE
Use the default serialization size

### DIFF
--- a/gen_player.c
+++ b/gen_player.c
@@ -81,7 +81,8 @@ static void run(gen_player *player)
 			register_section_handler(&buffer, (section_handler){.fun = psg_deserialize, .data = player->psg}, SECTION_PSG);
 			while (buffer.cur_pos < buffer.size)
 			{
-				load_section(&buffer);
+				if (!load_section(&buffer))
+					break;
 			}
 			player->reader.buffer.cur_pos += size;
 			free(buffer.handlers);

--- a/genesis.c
+++ b/genesis.c
@@ -189,7 +189,8 @@ void genesis_deserialize(deserialize_buffer *buf, genesis_context *gen)
 	register_section_handler(buf, (section_handler){.fun = cart_deserialize, .data = gen}, SECTION_MAPPER);
 	while (buf->cur_pos < buf->size)
 	{
-		load_section(buf);
+		if (!load_section(buf))
+			break;
 	}
 	update_z80_bank_pointer(gen);
 	adjust_int_cycle(gen->m68k, gen->vdp);

--- a/libblastem.c
+++ b/libblastem.c
@@ -184,14 +184,9 @@ RETRO_API void retro_run(void)
  * returned size is never allowed to be larger than a previous returned
  * value, to ensure that the frontend can allocate a save state buffer once.
  */
-static size_t serialize_size_cache;
 RETRO_API size_t retro_serialize_size(void)
 {
-	if (!serialize_size_cache) {
-		uint8_t *tmp = current_system->serialize(current_system, &serialize_size_cache);
-		free(tmp);
-	}
-	return serialize_size_cache;
+	return SERIALIZE_DEFAULT_SIZE;
 }
 
 /* Serializes internal state. If failed, or size is lower than
@@ -227,7 +222,6 @@ RETRO_API void retro_cheat_set(unsigned index, bool enabled, const char *code)
 static system_type stype;
 RETRO_API bool retro_load_game(const struct retro_game_info *game)
 {
-	serialize_size_cache = 0;
 	if (game->path) {
 		media.dir = path_dirname(game->path);
 		media.name = basename_no_extension(game->path);

--- a/serialize.c
+++ b/serialize.c
@@ -205,12 +205,15 @@ void load_buffer32(deserialize_buffer *buf, uint32_t *dst, size_t len)
 	}
 }
 
-void load_section(deserialize_buffer *buf)
+int load_section(deserialize_buffer *buf)
 {
 	if (!buf->handlers) {
 		fatal_error("load_section called on a deserialize_buffer with no handlers registered\n");
 	}
 	uint16_t section_id = load_int16(buf);
+	if (section_id == SECTION_END_OF_SERIALIZATION) {
+		return 0;
+	}
 	uint32_t size = load_int32(buf);
 	if (size > (buf->size - buf->cur_pos)) {
 		fatal_error("Section is bigger than remaining space in file");
@@ -218,12 +221,13 @@ void load_section(deserialize_buffer *buf)
 	if (section_id > buf->max_handler || !buf->handlers[section_id].fun) {
 		warning("No handler for section ID %d, save state may be from a newer version\n", section_id);
 		buf->cur_pos += size;
-		return;
+		return 1;
 	}
 	deserialize_buffer section;
 	init_deserialize(&section, buf->data + buf->cur_pos, size);
 	buf->handlers[section_id].fun(&section, buf->handlers[section_id].data);
 	buf->cur_pos += size;
+	return 1;
 }
 
 static const char sz_ident[] = "BLSTSZ\x01\x07";

--- a/serialize.c
+++ b/serialize.c
@@ -4,11 +4,6 @@
 #include "serialize.h"
 #include "util.h"
 
-#ifndef SERIALIZE_DEFAULT_SIZE
-#define SERIALIZE_DEFAULT_SIZE (256*1024) //default to enough for a Genesis save state
-#endif
-
-
 void init_serialize(serialize_buffer *buf)
 {
 	buf->storage = SERIALIZE_DEFAULT_SIZE;

--- a/serialize.h
+++ b/serialize.h
@@ -28,7 +28,7 @@ struct deserialize_buffer {
 };
 
 enum {
-	SECTION_HEADER,
+	SECTION_END_OF_SERIALIZATION,
 	SECTION_68000,
 	SECTION_Z80,
 	SECTION_VDP,
@@ -63,7 +63,7 @@ uint8_t load_int8(deserialize_buffer *buf);
 void load_buffer8(deserialize_buffer *buf, void *dst, size_t len);
 void load_buffer16(deserialize_buffer *buf, uint16_t *dst, size_t len);
 void load_buffer32(deserialize_buffer *buf, uint32_t *dst, size_t len);
-void load_section(deserialize_buffer *buf);
+int load_section(deserialize_buffer *buf);
 uint8_t save_to_file(serialize_buffer *buf, char *path);
 uint8_t load_from_file(deserialize_buffer *buf, char *path);
 #endif //SERIALIZE_H

--- a/serialize.h
+++ b/serialize.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifndef SERIALIZE_DEFAULT_SIZE
+#define SERIALIZE_DEFAULT_SIZE (256*1024) //default to enough for a Genesis save state
+#endif
+
 typedef struct {
 	size_t  size;
 	size_t  storage;

--- a/sms.c
+++ b/sms.c
@@ -309,7 +309,8 @@ void sms_deserialize(deserialize_buffer *buf, sms_context *sms)
 	//TODO: cart RAM
 	while (buf->cur_pos < buf->size)
 	{
-		load_section(buf);
+		if (!load_section(buf))
+			break;
 	}
 	z80_invalidate_code_range(sms->z80, 0xC000, 0x10000);
 	if (sms->bank_regs[0] & 8) {


### PR DESCRIPTION
This stops loading serialization sections when reaching the unused 0 section, makes the default serialization size available, and drops the cache which became invalid and instead return a large enough serialization size, avoiding to serialize twice as it is slow.

Fixes https://github.com/libretro/blastem/issues/23.