### PR TITLE
[osx] fix build failure for osx due to sed command for %.db.c rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ m68k.c : m68k.cpu cpu_dsl.py
 	./cpu_dsl.py -d goto $< > $@
 
 %.db.c : %.db
-	sed $< -e 's/"/\\"/g' -e 's/^\(.*\)$$/"\1\\n"/' -e'1s/^\(.*\)$$/const char $(shell echo $< | tr '.' '_')_data[] = \1/' -e '$$s/^\(.*\)$$/\1;/' > $@
+	sed -e 's/"/\\"/g' -e 's/^\(.*\)$$/"\1\\n"/' -e'1s/^\(.*\)$$/const char $(shell echo $< | tr '.' '_')_data[] = \1/' -e '$$s/^\(.*\)$$/\1;/' $< > $@
 
 %.o : %.S
 	$(CC) -c -o $@ $<


### PR DESCRIPTION
OSX doesn't like having the file input for sed before the command options.
Fails with error:

	sed: -e: No such file or directory
	sed: s/"/\\"/g: No such file or directory
	sed: -e: No such file or directory
	sed: s/^\(.*\)$/"\1\\n"/: No such file or directory
	sed: -e1s/^\(.*\)$/const char rom_db_data[] = \1/: No such file or directory
	sed: -e: No such file or directory
	sed: $s/^\(.*\)$/\1;/: No such file or directory

Solution is to move the $< input to the end. 

Have build tested using Kodi's libretro system. I'm not 100% sure whether this will have any adverse effects on other platforms that libretro builds, so any feedback around that would be good. I dont want to introduce a failure upstream for systems i cant test against.