### PR TITLE
libretro: reset the started flag when content is unloaded

### DIFF
--- a/libblastem.c
+++ b/libblastem.c
@@ -305,6 +305,9 @@ RETRO_API void retro_unload_game(void)
 	media.buffer = NULL;
 	current_system->free_context(current_system);
 	current_system = NULL;
+	//the next system loaded has never run, so retro_run() must start it rather
+	//than resume it; resuming would enter the recompiler at a NULL resume_pc
+	started = 0;
 }
 
 /* Gets region of game. */


### PR DESCRIPTION
Fixes #50 (the crash half of it).

`retro_run()` starts the system on its first call and resumes it on every later one, tracked by the file-scope `started` flag in `libblastem.c`. Nothing ever cleared that flag, so after `retro_unload_game()` the next content was *resumed* rather than started:

```c
static uint8_t started;
...
if (started)
    current_system->resume_context(current_system);
else {
    current_system->start_context(current_system, NULL);
    started = 1;
}
```

`resume_context()` ends up in `resume_68k()`, which enters the recompiler at `context->resume_pc`. On a system that has never run that field is NULL, so the generated `start_context` jumps to address 0 and the frontend dies on the first frame after the second game is loaded — exactly what closing content or switching games does.

Only the x86 recompiler is affected. The `NEW_CORE` interpreter path, which every non-x86 target builds, survives the same sequence, so the bug has been invisible on ARM.

### How it was verified

A small harness drives the core through RetroArch's own sequence — `retro_init` → `retro_load_game` → run → `retro_unload_game` → `retro_deinit` → `retro_init` → `retro_load_game` → run — with Sonic 1. The x86_64 cores run under `qemu-x86_64` (my machine is aarch64):

| core | first load | after reload |
|---|---|---|
| buildbot nightly, x86_64 | ok | **SIGSEGV** |
| built from current `libretro` branch, x86_64 | ok | **SIGSEGV** |
| built from 277e4a6 (pre-dates the recent sync), x86_64 | ok | **SIGSEGV** |
| built from current branch, aarch64 (interpreter) | ok | ok |
| **this patch, x86_64** | ok | **ok** |

The core dump shows `RIP = 0` with `resume_genesis` on the stack, which is that NULL `resume_pc` being jumped to.

Worth noting for #50: the 277e4a6 row is from before the upstream sync, so the crash is not a regression from it. The reporter also mentions Sonic 1 glitches; frames 200/400/600/800 rendered by the pre-sync and post-sync builds are bit-identical, so that part is not from the sync either and needs looking at separately.
