### PR TITLE
libretro: allocate the ROM buffer the way the core frees it (fixes the Close content crash on Windows)

### DIFF
--- a/libblastem.c
+++ b/libblastem.c
@@ -270,7 +270,9 @@ RETRO_API bool retro_load_game(const struct retro_game_info *game)
 			media.name = basename_no_extension(game->path);
 			media.extension = path_extension(game->path);
 		}
-		media.buffer = malloc(nearest_pow2(game->size));
+		//the buffer is freed with aligned_free() by the system context, so it
+		//needs the alignment header that aligned_calloc() puts in front of it
+		media.buffer = aligned_calloc(1, nearest_pow2(game->size), 16);
 		memcpy(media.buffer, game->data, game->size);
 		media.size = game->size;
 	} else {


### PR DESCRIPTION
Fixes the crash half of #50 that #51 did **not** cover. #51 fixed a real bug (resuming a system that had never been started), but the log attached to #50 ends on

```
[INFO] [Core] Unloading game...
```

so RetroArch is dying inside `retro_unload_game()`, before the reload path is ever reached. That is why @Tasosgemah and @hunterk still see it on Windows after #51 landed.

### What is wrong

The core answers `SET_CONTENT_INFO_OVERRIDE` with `need_fullpath = 0` for `md|gen|sms|gg|sg|sc|col|vgm|flac|wav|bin|rom`, so RetroArch hands it the ROM **in memory** (visible in the log as the `[Content Override] File Extension: 'md' - need_fullpath: FALSE` lines followed by `[Content] CRC32:`). In that branch `retro_load_game()` does

```c
media.buffer = malloc(nearest_pow2(game->size));
```

but the system context owns that buffer and releases it in `free_genesis()` with

```c
aligned_free(gen->cart);
```

and `aligned_free()` is

```c
uint8_t *buf = ptr;
buf -= buf[-1];
free(buf);
```

`aligned_calloc()` writes the alignment into `ret[-1]`; a plain `malloc()` buffer has no such byte, so what gets freed is whatever the allocator happens to keep in front of the block.

### Why only Windows

On glibc and musl the eight bytes in front of the user pointer are the chunk size, so on little-endian 64-bit `buf[-1]` is its most significant byte - always `0x00`. `aligned_free()` then degenerates into a plain `free()` and the mismatch is harmless. A Windows heap block header is not zero there, so `free()` gets a pointer that was never allocated.

### Verified

A harness drives the core exactly the way RetroArch does - `retro_init` → `retro_load_game` with `game->data` set → 60 frames → `retro_unload_game` → `retro_deinit`, twice in a row - with Sonic 1 on Linux aarch64. To get Windows' behaviour on Linux I ran it under an `LD_PRELOAD` shim that makes the byte in front of every `malloc` block non-zero (`0xAB`) and reports a free of anything that is not a block start instead of letting it corrupt the heap:

| | native Linux heap | non-zero header byte (Windows-like) |
|---|---|---|
| current `libretro` branch | ok | **`INVALID FREE: 0xffffabb130c5 is -171 bytes off a live 524288 byte block`** |
| this patch | ok | ok |

`171` is `0xAB`, and `524288` is `nearest_pow2()` of the Sonic 1 ROM, so that is `aligned_free()` walking backwards off the cart buffer. With the patch both load/unload cycles complete cleanly under the shim.

### Why fix it on the allocation side

`romdb.c` also `aligned_free`s this buffer when it grows it for Mega Everdrive SSF (`romdb.c:276`) and multi-game carts (`romdb.c:1282`), so the whole codebase already assumes the ROM buffer came from `aligned_calloc()`. Matching that is one line; special-casing the free would mean touching every one of those sites.

### Note on the regression claim in #51

I wrote there that the crash was not a regression from the upstream sync. That was true of the resume crash I was chasing, but not of this one: before the sync (`277e4a6`) the ROM buffer was `malloc`'d everywhere and `free_genesis()` did `free(gen->cart)`, which was consistent. The sync moved the standalone loader to `aligned_calloc(..., 16)` and the free to `aligned_free()` while `libblastem.c` stayed on `malloc()`. So @Jobima1st was right that this arrived with the last core update.

The same mismatch is present in upstream BlastEm (hg tip `732f5689d438`), so it is worth passing on there as well.

This does not touch the Sonic 1 title screen glitches also mentioned in #50 - those reproduce in standalone BlastEm too, so they need to be chased upstream separately.
