### PR TITLE
libretro: format and system parity with the standalone build, plus three crash/hang fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,9 @@ UPD78K2RUNOBJS:=upd78k2.o upd78k2run.o util.o backend.o tern.o
 UPDDISOBJS:=upddis.o upd78k2_dis.o disasm.o tern.o util.o backend.o
 SH2DISOBJS:=sh2dis.o sh2_decode.o disasm.o tern.o util.o backend.o
 
-LIBCFLAGS=$(CFLAGS) -fpic -DIS_LIB -DDISABLE_ZLIB -DDISABLE_NUKLEAR
+#zlib is left enabled here: LIBOBJS already links $(LIBZOBJS), so this costs no
+#extra objects and makes romopen() a gzopen() that transparently handles gzip
+LIBCFLAGS=$(CFLAGS) -fpic -DIS_LIB -DDISABLE_NUKLEAR
 
 all : $(ALL)
 

--- a/libblastem.c
+++ b/libblastem.c
@@ -49,7 +49,7 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 	//would make the frontend hand us the raw interleaved buffer instead and load garbage.
 	static const struct retro_system_content_info_override scio[] = {
 		{
-			.extensions = "md|gen|32x|sms|gg|sg|sc|sf7|col|vgm|flac|wav|bin|rom",
+			.extensions = "md|gen|32x|sms|gg|sg|sg1|sc|sc3|sf7|col|vgm|flac|wav|bin|rom",
 			.need_fullpath = 0,
 			.persistent_data = 0
 		},
@@ -143,7 +143,7 @@ RETRO_API void retro_get_system_info(struct retro_system_info *info)
 {
 	info->library_name = "BlastEm";
 	info->library_version = BLASTEM_VERSION;
-	info->valid_extensions = "md|gen|smd|32x|sms|gg|sg|sc|sf7|col|cue|toc|iso|vgm|flac|wav|bin|rom";
+	info->valid_extensions = "md|gen|smd|32x|sms|gg|sg|sg1|sc|sc3|sf7|col|cue|toc|iso|vgm|flac|wav|bin|rom";
 	info->need_fullpath = 1;
 	info->block_extract = 0;
 }

--- a/libblastem.c
+++ b/libblastem.c
@@ -188,6 +188,7 @@ RETRO_API void retro_get_system_info(struct retro_system_info *info)
 
 static vid_std video_standard;
 static uint32_t last_width, last_height;
+static uint8_t frame_presented;
 static uint32_t overscan_top, overscan_bot, overscan_left, overscan_right;
 static void update_overscan(void)
 {
@@ -251,11 +252,18 @@ RETRO_API void retro_reset(void)
 static uint8_t started;
 RETRO_API void retro_run(void)
 {
+	frame_presented = 0;
 	if (started) {
 		current_system->resume_context(current_system);
 	} else {
 		current_system->start_context(current_system, NULL);
 		started = 1;
+	}
+	//The media player has no video, so it returns without presenting anything.
+	//Hand the frontend the (blank) framebuffer anyway so it still gets one frame
+	//per call and its pacing and audio sync have something to run against.
+	if (!frame_presented) {
+		render_framebuffer_updated(render_get_active_framebuffer(), LINEBUF_SIZE);
 	}
 }
 
@@ -501,6 +509,7 @@ void render_framebuffer_updated(uint8_t which, int width)
 		last_height = height;
 	}
 	retro_video_refresh(fb + overscan_left + LINEBUF_SIZE * overscan_top, width, height, LINEBUF_SIZE * sizeof(uint32_t));
+	frame_presented = 1;
 	system_request_exit(current_system, 0);
 }
 

--- a/libblastem.c
+++ b/libblastem.c
@@ -143,7 +143,10 @@ RETRO_API void retro_get_system_info(struct retro_system_info *info)
 {
 	info->library_name = "BlastEm";
 	info->library_version = BLASTEM_VERSION;
-	info->valid_extensions = "md|gen|smd|32x|sms|gg|sg|sg1|sc|sc3|sf7|col|cue|toc|iso|vgm|flac|wav|bin|rom";
+	//gz and vgz are absent from the content info override for the same reason as
+	//smd: they only decompress on the need_fullpath path, where romopen() is a
+	//gzopen(). Handed over as data they would be loaded as raw deflate streams.
+	info->valid_extensions = "md|gen|smd|32x|sms|gg|sg|sg1|sc|sc3|sf7|col|cue|toc|iso|vgm|vgz|flac|wav|bin|rom|gz";
 	info->need_fullpath = 1;
 	info->block_extract = 0;
 }

--- a/libblastem.c
+++ b/libblastem.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "libretro.h"
@@ -12,6 +13,34 @@
 #include "cdimage.h"
 
 tern_node *config;
+
+//The machines the standalone build can force with "-m". Detection handles most
+//of them from the media itself, but it cannot tell a LaserActive disc from any
+//other Sega CD one, and header based guesses are wrong often enough on Pico and
+//Copera titles to be worth overriding.
+//
+//"jag" is deliberately missing: alloc_config_system() has no case for
+//SYSTEM_JAGUAR and returns NULL, so offering it could only ever fail the load.
+//"laseractive" keeps the spelling it shipped with, because frontends persist
+//the chosen value in their config.
+static const struct {
+	const char *value;
+	system_type stype;
+} system_type_options[] = {
+	{ "gen",         SYSTEM_GENESIS },
+	{ "sms",         SYSTEM_SMS },
+	{ "gg",          SYSTEM_GAME_GEAR },
+	{ "sg1000",      SYSTEM_SG1000 },
+	{ "sc3000",      SYSTEM_SC3000 },
+	{ "32x",         SYSTEM_32X },
+	{ "32xcd",       SYSTEM_32XCD },
+	{ "pico",        SYSTEM_PICO },
+	{ "copera",      SYSTEM_COPERA },
+	{ "laseractive", SYSTEM_LASERACTIVE },
+	{ "mediaplayer", SYSTEM_MEDIA_PLAYER }
+};
+#define NUM_SYSTEM_TYPE_OPTIONS (sizeof(system_type_options)/sizeof(*system_type_options))
+
 static retro_environment_t retro_environment;
 RETRO_API void retro_set_environment(retro_environment_t re)
 {
@@ -57,13 +86,19 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 	};
 	re(RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE, (void *)scio);
 
-	//Pioneer LaserActive images are indistinguishable from other Sega CD media, so
-	//detect_system_type() can never return SYSTEM_LASERACTIVE on its own. The standalone
-	//build relies on the "-m laser" switch for this; expose the same choice as an option.
-	static const struct retro_variable vars[] = {
-		{ "blastem_system_type", "System type; auto|laseractive" },
+	//Built from the table rather than spelled out so the advertised values and the
+	//ones option_system_type() accepts cannot drift apart. Rebuilt from scratch on
+	//every call because a frontend may set the environment callback more than once.
+	static char system_type_desc[256];
+	int len = snprintf(system_type_desc, sizeof(system_type_desc), "System type; auto");
+	for (size_t i = 0; i < NUM_SYSTEM_TYPE_OPTIONS && len < (int)sizeof(system_type_desc); i++) {
+		len += snprintf(system_type_desc + len, sizeof(system_type_desc) - len, "|%s", system_type_options[i].value);
+	}
+	static struct retro_variable vars[] = {
+		{ "blastem_system_type", NULL },
 		{ NULL, NULL }
 	};
+	vars[0].value = system_type_desc;
 	re(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars);
 
 	const char *system_dir = NULL;
@@ -282,8 +317,10 @@ static system_type option_system_type(void)
 	if (!retro_environment(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || !var.value) {
 		return SYSTEM_UNKNOWN;
 	}
-	if (!strcmp(var.value, "laseractive")) {
-		return SYSTEM_LASERACTIVE;
+	for (size_t i = 0; i < NUM_SYSTEM_TYPE_OPTIONS; i++) {
+		if (!strcmp(var.value, system_type_options[i].value)) {
+			return system_type_options[i].stype;
+		}
 	}
 	return SYSTEM_UNKNOWN;
 }

--- a/libblastem.c
+++ b/libblastem.c
@@ -44,9 +44,12 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 
 	re(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, (void *)desc);
 	
+	//NOTE: "smd" is deliberately absent here. Interleaved Super Magic Drive ROMs are
+	//unscrambled by load_media(), which only runs on the need_fullpath path. Adding smd
+	//would make the frontend hand us the raw interleaved buffer instead and load garbage.
 	static const struct retro_system_content_info_override scio[] = {
 		{
-			.extensions = "md|gen|sms|gg|sg|sc|col|vgm|flac|wav|bin|rom",
+			.extensions = "md|gen|32x|sms|gg|sg|sc|sf7|col|vgm|flac|wav|bin|rom",
 			.need_fullpath = 0,
 			.persistent_data = 0
 		},
@@ -128,7 +131,7 @@ RETRO_API void retro_get_system_info(struct retro_system_info *info)
 {
 	info->library_name = "BlastEm";
 	info->library_version = BLASTEM_VERSION;
-	info->valid_extensions = "md|gen|sms|gg|sg|sc|col|cue|toc|iso|vgm|flac|wav|bin|rom";
+	info->valid_extensions = "md|gen|smd|32x|sms|gg|sg|sc|sf7|col|cue|toc|iso|vgm|flac|wav|bin|rom";
 	info->need_fullpath = 1;
 	info->block_extract = 0;
 }

--- a/libblastem.c
+++ b/libblastem.c
@@ -56,7 +56,16 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 		{0}
 	};
 	re(RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE, (void *)scio);
-	
+
+	//Pioneer LaserActive images are indistinguishable from other Sega CD media, so
+	//detect_system_type() can never return SYSTEM_LASERACTIVE on its own. The standalone
+	//build relies on the "-m laser" switch for this; expose the same choice as an option.
+	static const struct retro_variable vars[] = {
+		{ "blastem_system_type", "System type; auto|laseractive" },
+		{ NULL, NULL }
+	};
+	re(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars);
+
 	const char *system_dir = NULL;
 	re(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
 	printf("system_dir: %s\n", system_dir);
@@ -65,6 +74,9 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 		config = tern_insert_path(config, "system\0scd_bios_eu\0", (tern_val){.ptrval = alloc_concat(system_dir, "/bios_CD_E.bin")}, TVAL_PTR);
 		config = tern_insert_path(config, "system\0scd_bios_jp\0", (tern_val){.ptrval = alloc_concat(system_dir, "/bios_CD_J.bin")}, TVAL_PTR);
 		config = tern_insert_path(config, "system\0coleco_bios_path\0", (tern_val){.ptrval = alloc_concat(system_dir, "/colecovision.rom")}, TVAL_PTR);
+		//Without an absolute path here alloc_laseractive() falls back to read_bundled_file(),
+		//which looks next to the standalone binary and finds nothing in a libretro build.
+		config = tern_insert_path(config, "system\0laseractive_upd_rom\0", (tern_val){.ptrval = alloc_concat(system_dir, "/laseractive_dyw_1322a.bin")}, TVAL_PTR);
 	}
 }
 
@@ -261,6 +273,18 @@ RETRO_API void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
 }
 
+static system_type option_system_type(void)
+{
+	struct retro_variable var = { .key = "blastem_system_type" };
+	if (!retro_environment(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || !var.value) {
+		return SYSTEM_UNKNOWN;
+	}
+	if (!strcmp(var.value, "laseractive")) {
+		return SYSTEM_LASERACTIVE;
+	}
+	return SYSTEM_UNKNOWN;
+}
+
 /* Loads a game. */
 static system_type stype;
 RETRO_API bool retro_load_game(const struct retro_game_info *game)
@@ -280,6 +304,12 @@ RETRO_API bool retro_load_game(const struct retro_game_info *game)
 		media.size = game->size;
 	} else {
 		load_media((char *)game->path, &media, &stype);
+	}
+	//Same precedence as blastem.c: an explicit choice wins over whatever load_media()
+	//worked out, and detection only runs when nothing has been decided yet.
+	system_type force_stype = option_system_type();
+	if (force_stype != SYSTEM_UNKNOWN) {
+		stype = force_stype;
 	}
 	if (stype == SYSTEM_UNKNOWN) {
 		stype = detect_system_type(&media);

--- a/mediaplayer.c
+++ b/mediaplayer.c
@@ -950,9 +950,14 @@ static void resume_player(system_header *system)
 #endif
 			break;
 		}
-	//TODO: Fix this for libretro build properly
 #ifndef IS_LIB
 		render_update_display();
+#else
+		//A libretro frontend expects retro_run() to return once per frame. The
+		//other systems get there because presenting a frame calls request_exit(),
+		//but the player has no video at all, so it has to yield on its own or the
+		//frontend never regains control.
+		player->should_return = 1;
 #endif
 	}
 }

--- a/system.c
+++ b/system.c
@@ -291,6 +291,15 @@ uint32_t load_media(char * filename, system_media *dst, system_type *stype)
 	return ret;
 }
 
+//media->extension is NULL for a file with no dot in its name, and for libretro
+//content handed to the core without a path, so every check here has to tolerate
+//it. Comparison is case insensitive because path_extension() returns the
+//extension exactly as the user spelled it.
+static uint8_t ext_is(system_media *media, const char *ext)
+{
+	return media->extension && !strcasecmp(ext, media->extension);
+}
+
 system_type detect_system_type(system_media *media)
 {
 	static char *pico_names[] = {
@@ -314,7 +323,7 @@ system_type detect_system_type(system_media *media)
 		//This string is part of the "security" block so is more reliable than checking for "SEGA 32X"
 		//in the system type header field
 		static const char *mars_security = "MARS Initial & Security Program          Cartridge Version";
-		if (safe_cmp(mars_security, 0x512, media->buffer, media->size) || !strcmp("32x", media->extension)) {
+		if (safe_cmp(mars_security, 0x512, media->buffer, media->size) || ext_is(media, "32x")) {
 			return SYSTEM_32X;
 		}
 		return SYSTEM_GENESIS;
@@ -323,7 +332,7 @@ system_type detect_system_type(system_media *media)
 		|| safe_cmp("TMR SEGA", 0x3FF0, media->buffer, media->size)
 		|| safe_cmp("TMR SEGA", 0x7FF0, media->buffer, media->size)
 	) {
-		return strcmp("gg", media->extension) ? SYSTEM_SMS : SYSTEM_GAME_GEAR;
+		return ext_is(media, "gg") ? SYSTEM_GAME_GEAR : SYSTEM_SMS;
 	}
 	if (media->size > 400) {
 		uint8_t *buffer = media->buffer;
@@ -370,33 +379,29 @@ system_type detect_system_type(system_media *media)
 	//TODO: Detect Jaguar ROMs here
 
 	//Header based detection failed, examine filename for clues
-	if (media->extension) {
-		if (!strcasecmp("md", media->extension) || !strcasecmp("gen", media->extension)) {
-			return SYSTEM_GENESIS;
-		}
-		if (!strcasecmp("32x", media->extension)) {
-			return SYSTEM_32X;
-		}
-		if (!strcasecmp("sms", media->extension)) {
-			return SYSTEM_SMS;
-		}
-		if (!strcasecmp("gg", media->extension)) {
-			return SYSTEM_GAME_GEAR;
-		}
-		if (!strcasecmp("sg", media->extension) || !strcasecmp("sg1", media->extension)) {
-			return SYSTEM_SG1000;
-		}
-		if (!strcasecmp("sc", media->extension) || !strcasecmp("sf7", media->extension) ||
-			!strcasecmp("sc3", media->extension)
-		) {
-			return SYSTEM_SC3000;
-		}
-		if (!strcasecmp("j64", media->extension)) {
-			return SYSTEM_JAGUAR;
-		}
-		if (!strcasecmp("col", media->extension)) {
-			return SYSTEM_COLECOVISION;
-		}
+	if (ext_is(media, "md") || ext_is(media, "gen")) {
+		return SYSTEM_GENESIS;
+	}
+	if (ext_is(media, "32x")) {
+		return SYSTEM_32X;
+	}
+	if (ext_is(media, "sms")) {
+		return SYSTEM_SMS;
+	}
+	if (ext_is(media, "gg")) {
+		return SYSTEM_GAME_GEAR;
+	}
+	if (ext_is(media, "sg") || ext_is(media, "sg1")) {
+		return SYSTEM_SG1000;
+	}
+	if (ext_is(media, "sc") || ext_is(media, "sf7") || ext_is(media, "sc3")) {
+		return SYSTEM_SC3000;
+	}
+	if (ext_is(media, "j64")) {
+		return SYSTEM_JAGUAR;
+	}
+	if (ext_is(media, "col")) {
+		return SYSTEM_COLECOVISION;
 	}
 
 	//More certain checks failed, look for a valid 68K reset vector

--- a/system.c
+++ b/system.c
@@ -371,30 +371,30 @@ system_type detect_system_type(system_media *media)
 
 	//Header based detection failed, examine filename for clues
 	if (media->extension) {
-		if (!strcmp("md", media->extension) || !strcmp("gen", media->extension)) {
+		if (!strcasecmp("md", media->extension) || !strcasecmp("gen", media->extension)) {
 			return SYSTEM_GENESIS;
 		}
-		if (!strcmp("32x", media->extension)) {
+		if (!strcasecmp("32x", media->extension)) {
 			return SYSTEM_32X;
 		}
-		if (!strcmp("sms", media->extension)) {
+		if (!strcasecmp("sms", media->extension)) {
 			return SYSTEM_SMS;
 		}
-		if (!strcmp("gg", media->extension)) {
+		if (!strcasecmp("gg", media->extension)) {
 			return SYSTEM_GAME_GEAR;
 		}
-		if (!strcmp("sg", media->extension) || !strcmp("sg1", media->extension)) {
+		if (!strcasecmp("sg", media->extension) || !strcasecmp("sg1", media->extension)) {
 			return SYSTEM_SG1000;
 		}
-		if (!strcmp("sc", media->extension) || !strcmp("sf7", media->extension) ||
-			!strcmp("sc3", media->extension)
+		if (!strcasecmp("sc", media->extension) || !strcasecmp("sf7", media->extension) ||
+			!strcasecmp("sc3", media->extension)
 		) {
 			return SYSTEM_SC3000;
 		}
-		if (!strcmp("j64", media->extension)) {
+		if (!strcasecmp("j64", media->extension)) {
 			return SYSTEM_JAGUAR;
 		}
-		if (!strcmp("col", media->extension)) {
+		if (!strcasecmp("col", media->extension)) {
 			return SYSTEM_COLECOVISION;
 		}
 	}


### PR DESCRIPTION
Brings the libretro core up to parity with what the standalone build accepts, and fixes three bugs found along the way. Each commit stands on its own, so anything here can be dropped without disturbing the rest.

## Formats

`smd`, `32x`, `sf7`, `sg1` and `sc3` were missing from `valid_extensions`, so the frontend refused files that `detect_system_type()` handles perfectly well. `sg1` and `sc3` go slightly beyond the standalone list in `valid_exts`, which is why they only ever worked outside archives.

`smd`, `gz` and `vgz` are advertised but deliberately kept out of the content info override. Deinterleaving and decompression both happen inside `load_media()`, which only runs on the `need_fullpath` path; handed over as data these would be loaded as raw interleaved or deflate-compressed garbage.

gzip support just needed `DISABLE_ZLIB` dropped from `LIBCFLAGS`. It costs nothing in link size because `LIBOBJS` already pulls in `$(LIBZOBJS)` for `event_log`. `vgz` needs no handling of its own: `gzopen()` is transparent, so the file is decompressed whatever it is called, and the media player is then picked up from the `Vgm` magic rather than the extension.

## Systems

The core had no way to reach `SYSTEM_LASERACTIVE`, because a LaserActive disc is indistinguishable from any other Sega CD one and the standalone build gets there through `-m laser`. There is now a `blastem_system_type` option covering the same set, applied with the precedence `blastem.c` uses: an explicit choice overrides whatever `load_media()` worked out, and autodetection only runs when nothing has been decided.

The advertised values and the ones the parser accepts are driven from one table so they cannot drift apart. `jag` is left out, since `alloc_config_system()` has no case for `SYSTEM_JAGUAR` and returns `NULL`.

`laseractive_upd_rom` now points at the frontend's system directory. Without an absolute path `alloc_laseractive()` falls back to `read_bundled_file()`, which looks next to the standalone binary and finds nothing in a shared library, so the option would have silently produced a machine with no PAC firmware.

## Bug fixes

**NULL dereference in `detect_system_type()`.** Two extension comparisons sit above the `if (media->extension)` guard. `path_extension()` returns `NULL` for a file with no dot in its name, and the core only fills in `media.extension` when the frontend supplies a path, which it is not obliged to do for content passed as data. Any ordinary Genesis ROM reaches the `32x` check, so loading one without a path segfaults. This affects the standalone build too, via a file with no extension.

**Case sensitive extension checks in the same place.** A `.GG` file with a `TMR SEGA` header came out as `SYSTEM_SMS` instead of `SYSTEM_GAME_GEAR`, and a `.32X` file without the MARS security block fell through to `SYSTEM_GENESIS`.

**The media player hung the frontend.** `resume_player()` loops until `should_exit` or `should_return`, and the only thing that ever sets `should_return` in a libretro build is `request_exit()`, which the core calls from `render_framebuffer_updated()`. The player produces no video, so `retro_run()` never returned on any `vgm`, `vgz`, `flac` or `wav` file. `render_update_display()`, which breaks the loop in the standalone build, is compiled out under `IS_LIB`. It now yields after each iteration; `vgm_frame()` and its siblings each process exactly one frame worth of samples, so one pass per `retro_run()` is also the right playback rate.

## Testing

Exercised on aarch64 with a harness that drives two full frontend cycles (`init` → `load_game` → 20 frames → `unload_game` → `deinit`), counting `video_refresh` and `audio_sample_batch` calls.

| case | before | after |
|---|---|---|
| Genesis ROM, `game->data` with `path = NULL` | SIGSEGV | 320x224 |
| `TEST.GG` vs `test.gg` | 256x224 vs 256x275 | 256x275 both |
| gzipped ROM on the `need_fullpath` path | load failed | 320x224 |
| gzip named `.vgz` | load failed | 320x224 |
| `vgm` and `vgz` | hung indefinitely | 40 frames, audio produced |
| Genesis ROM, data and fullpath paths | 320x224 | 320x224 |

Systems with video are unaffected by the blank frame added to `retro_run()`: the same ROM produces an identical 13268 audio batches and 53072 samples over 60 frames before and after.

Not covered: LaserActive itself was not run against real media, since that needs `laseractive_dyw_1322a.bin` and an LD-ROM² image. The option is verified to select `SYSTEM_LASERACTIVE` and reach `alloc_laseractive()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
