### PR TITLE
libretro: read media through the frontend's VFS

### DIFF
--- a/32x.c
+++ b/32x.c
@@ -8,6 +8,7 @@
 #include "blastem.h"
 #include "util.h"
 #include "debug.h"
+#include "media_file.h"
 
 #define MAX_SH2_CYCLES 2000
 
@@ -1069,11 +1070,11 @@ static uint16_t *get_68K_vector_rom(uint32_t size)
 	}
 	uint16_t *ret = calloc(1, size);
 	char *m68k_path = tern_find_path_default(config, "system\0s32x_68k_bios\0", (tern_val){.ptrval = "32X_G_BIOS.bin"}, TVAL_PTR).ptrval;
-	FILE *f = fopen(m68k_path, "rb");
+	media_file *f = media_fopen(m68k_path, "rb");
 	if (f) {
-		fread(ret, 1, 0x100, f);
+		media_fread(ret, 1, 0x100, f);
 		byteswap_rom(0x100, ret);
-		fclose(f);
+		media_fclose(f);
 	} else {
 		warning("32X 68K BIOS not found at %s. Some games may function without it, but it is needed for full compatibility\n", m68k_path);
 		ret[0] = ret[1] = 0;
@@ -1414,11 +1415,11 @@ s32x *alloc_32x(system_media *media, uint8_t pal, uint8_t cd_boot)
 	}
 	main_map[5].buffer = aligned_calloc(1, main_map[5].end, 16);
 	char *main_path = tern_find_path_default(config, "system\0s32x_main_bios\0", (tern_val){.ptrval = "32X_M_BIOS.bin"}, TVAL_PTR).ptrval;
-	FILE *f = fopen(main_path, "rb");
+	media_file *f = media_fopen(main_path, "rb");
 	if (f) {
-		fread(main_map[5].buffer, 1, main_map[5].end, f);
+		media_fread(main_map[5].buffer, 1, main_map[5].end, f);
 		byteswap_rom(main_map[5].end, main_map[5].buffer);
-		fclose(f);
+		media_fclose(f);
 	} else {
 		warning("32X Main SH2 BIOS not found at %s. 32X will not function correctly until you fix your config\n", main_path);
 	}
@@ -1446,11 +1447,11 @@ s32x *alloc_32x(system_media *media, uint8_t pal, uint8_t cd_boot)
 	}
 	sub_map[5].buffer = aligned_calloc(1, sub_map[5].end, 16);
 	char *sub_path = tern_find_path_default(config, "system\0s32x_sub_bios\0", (tern_val){.ptrval = "32X_S_BIOS.bin"}, TVAL_PTR).ptrval;
-	f = fopen(sub_path, "rb");
+	f = media_fopen(sub_path, "rb");
 	if (f) {
-		fread(sub_map[5].buffer, 1, sub_map[5].end, f);
+		media_fread(sub_map[5].buffer, 1, sub_map[5].end, f);
 		byteswap_rom(sub_map[5].end, sub_map[5].buffer);
-		fclose(f);
+		media_fclose(f);
 	} else {
 		warning("32X Sub SH2 BIOS not found at %s. 32X will not function correctly until you fix your config\n", sub_path);
 	}

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,9 @@ endif
 
 MAINOBJS:=$(COREOBJS) blastem.o $(RENDEROBJS) zip.o  menu.o debug.o gdb_remote.o bindings.o oscilloscope.o
 
-LIBOBJS:=$(COREOBJS) libblastem.o lib_stubs.o rom.db.o $(LIBZOBJS)
+#vfs_file.o only in this list: it is the libretro build's file layer, and the
+#standalone one keeps using stdio directly (see media_file.h).
+LIBOBJS:=$(COREOBJS) libblastem.o lib_stubs.o rom.db.o vfs_file.o $(LIBZOBJS)
 
 ifdef NONUKLEAR
 CFLAGS+= -DDISABLE_NUKLEAR

--- a/cdimage.c
+++ b/cdimage.c
@@ -123,13 +123,13 @@ static uint8_t bin_seek(system_media *media, uint32_t sector)
 					if (!media->tmp_buffer) {
 						media->tmp_buffer = calloc(1, 96);
 					}
-					fseek(media->tracks[track].f, media->tracks[track].file_offset + (rel + 1) * media->tracks[track].sector_bytes - 96, SEEK_SET);
-					int bytes = fread(media->tmp_buffer, 1, 96, media->tracks[track].f);
+					media_fseek(media->tracks[track].f, media->tracks[track].file_offset + (rel + 1) * media->tracks[track].sector_bytes - 96, SEEK_SET);
+					int bytes = media_fread(media->tmp_buffer, 1, 96, media->tracks[track].f);
 					if (bytes != 96) {
 						fprintf(stderr, "Only read %d subcode bytes\n", bytes);
 					}
 				}
-				fseek(media->tracks[track].f, media->tracks[track].file_offset + rel * media->tracks[track].sector_bytes, SEEK_SET);
+				media_fseek(media->tracks[track].f, media->tracks[track].file_offset + rel * media->tracks[track].sector_bytes, SEEK_SET);
 			}
 		}
 		if (media->tracks[track].type == TRACK_DATA) {
@@ -185,9 +185,9 @@ static uint8_t bin_read(system_media *media, uint32_t offset)
 			if (offset & 1) {
 				retval = media->byte_storage[0];
 			}
-			media->byte_storage[0] = fgetc(media->tracks[media->cur_track].f);
+			media->byte_storage[0] = media_fgetc(media->tracks[media->cur_track].f);
 		} else {
-			retval = fgetc(media->tracks[media->cur_track].f);
+			retval = media_fgetc(media->tracks[media->cur_track].f);
 		}
 	}
 	if (offset >= 12 && media->tracks[media->cur_track].type == TRACK_DATA) {
@@ -245,7 +245,7 @@ uint8_t parse_cue(system_media *media)
 	line = media->buffer;
 	int track = -1;
 	uint8_t audio_byte_swap = 0;
-	FILE *f = NULL;
+	media_file *f = NULL;
 	flac_file *flac = NULL;
 	int track_of_file = -1;
 	uint8_t has_index_0 = 0;
@@ -314,13 +314,13 @@ uint8_t parse_cue(system_media *media)
 							if (flac) {
 								track_size = flac->total_samples * 4;
 							} else if (f) {
-								track_size = file_size(f);
+								track_size = media_file_size(f);
 							}
 							track_size -= tracks[track].file_offset;
 							tracks[track].end_lba = tracks[track].pregap_lba + tracks[track].fake_pregap + track_size / tracks[track].sector_bytes;
 						}
 						flac = NULL;
-						f = fopen(fname, "rb");
+						f = media_fopen(fname, "rb");
 						if (!f) {
 							fatal_error("Failed to open %s specified by FILE command in CUE sheet %s.%s\n", fname, media->name, media->extension);
 						}
@@ -343,7 +343,7 @@ uint8_t parse_cue(system_media *media)
 										}
 										extra_offset = wave.data_offset;
 									} else {
-										fseek(f, 0, SEEK_SET);
+										media_fseek(f, 0, SEEK_SET);
 										flac = flac_file_from_file(f);
 										if (!flac) {
 											fatal_error("WAVE file %s in cue sheet %s.%s is neither a valid WAVE nor a valid FLAC file\n", fname, media->name, media->extension);
@@ -406,9 +406,9 @@ uint8_t parse_cue(system_media *media)
 								if (!tracks[track].fake_pregap) {
 									if (tracks[track].type == TRACK_DATA && tracks[track].sector_bytes == 2352) {
 										//Infer pregap from position in sector header
-										fseek(f, start_lba + 12, SEEK_SET);
+										media_fseek(f, start_lba + 12, SEEK_SET);
 										uint8_t timecode[3];
-										if (sizeof(timecode) == fread(timecode, 1, sizeof(timecode), f)) {
+										if (sizeof(timecode) == media_fread(timecode, 1, sizeof(timecode), f)) {
 											tracks[track].fake_pregap = (timecode[0] >> 4) * 600;
 											tracks[track].fake_pregap += (timecode[0] & 0xF) * 60;
 											tracks[track].fake_pregap += (timecode[1] >> 4) * 10;
@@ -445,7 +445,7 @@ uint8_t parse_cue(system_media *media)
 		if (flac) {
 			track_size = flac->total_samples * 4;
 		} else if (f) {
-			track_size = file_size(f);
+			track_size = media_file_size(f);
 		}
 		track_size -= tracks[track].file_offset;
 		tracks[track].end_lba = tracks[track].pregap_lba + tracks[track].fake_pregap + track_size / tracks[track].sector_bytes;
@@ -454,8 +454,8 @@ uint8_t parse_cue(system_media *media)
 			//replace cue sheet with first sector
 			aligned_free(media->buffer);
 			media->buffer = calloc(2048, 1);
-			fseek(tracks[0].f, tracks[0].sector_bytes >= 2352 ? 16 : 0, SEEK_SET);
-			media->size = fread(media->buffer, 1, 2048, tracks[0].f);
+			media_fseek(tracks[0].f, tracks[0].sector_bytes >= 2352 ? 16 : 0, SEEK_SET);
+			media->size = media_fread(media->buffer, 1, 2048, tracks[0].f);
 		}
 		media->seek = bin_seek;
 		media->read = bin_read;
@@ -486,7 +486,7 @@ uint8_t parse_toc(system_media *media)
 	media->tracks = tracks;
 	line = media->buffer;
 	char *last_file_name = NULL;
-	FILE *f = NULL;
+	media_file *f = NULL;
 	int track = -1;
 	do {
 		char *cmd = cmd_start(line);
@@ -557,7 +557,7 @@ uint8_t parse_toc(system_media *media)
 										memcpy(fname + dirlen + 1, fname_start, fname_end-fname_start);
 										fname[dirlen + 1 + (fname_end-fname_start)] = 0;
 									}
-									f = fopen(fname, "rb");
+									f = media_fopen(fname, "rb");
 									if (!f) {
 										fatal_error("Failed to open %s specified by DATAFILE command in TOC file %s.%s\n", fname, media->name, media->extension);
 									}
@@ -584,7 +584,7 @@ uint8_t parse_toc(system_media *media)
 									uint32_t length = timecode_to_lba(cmd);
 									tracks[track].end_lba += length;
 								} else {
-									long fsize = file_size(f);
+									long fsize = media_file_size(f);
 									tracks[track].end_lba += (fsize - tracks[track].file_offset) / tracks[track].sector_bytes;
 								}
 							}
@@ -617,8 +617,8 @@ uint8_t parse_toc(system_media *media)
 		if (tracks[0].type == TRACK_DATA && tracks[0].sector_bytes == 2352) {
 			// if the first track is a data track, don't trust the TOC file and look at the MM:SS:FF from first sector
 			uint8_t msf[3];
-			fseek(tracks[0].f, 12, SEEK_SET);
-			if (sizeof(msf) == fread(msf, 1, sizeof(msf), tracks[0].f)) {
+			media_fseek(tracks[0].f, 12, SEEK_SET);
+			if (sizeof(msf) == media_fread(msf, 1, sizeof(msf), tracks[0].f)) {
 				tracks[0].fake_pregap = msf[2] + (msf[0] * 60 + msf[1]) * 75;
 			}
 		} else if (!tracks[0].fake_pregap) {
@@ -638,8 +638,8 @@ uint8_t parse_toc(system_media *media)
 			}
 		}
 
-		fseek(tracks[0].f, tracks[0].sector_bytes == 2352 ? 16 : 0, SEEK_SET);
-		media->size = fread(media->buffer, 1, 2048, tracks[0].f);
+		media_fseek(tracks[0].f, tracks[0].sector_bytes == 2352 ? 16 : 0, SEEK_SET);
+		media->size = media_fread(media->buffer, 1, 2048, tracks[0].f);
 		media->seek = bin_seek;
 		media->read = bin_read;
 		media->read_subcodes = bin_subcode_read;
@@ -652,12 +652,12 @@ uint8_t parse_toc(system_media *media)
 
 uint32_t make_iso_media(system_media *media, const char *filename)
 {
-	FILE *f = fopen(filename, "rb");
+	media_file *f = media_fopen(filename, "rb");
 	if (!f) {
 		return 0;
 	}
 	media->buffer = calloc(2048, 1);
-	media->size = fread(media->buffer, 1, 2048, f);
+	media->size = media_fread(media->buffer, 1, 2048, f);
 	media->num_tracks = 1;
 	media->tracks = calloc(sizeof(track_info), 1);
 	media->tracks[0] = (track_info){
@@ -665,7 +665,7 @@ uint32_t make_iso_media(system_media *media, const char *filename)
 		.file_offset = 0,
 		.fake_pregap = 2 * 75,
 		.start_lba = 0,
-		.end_lba = file_size(f),
+		.end_lba = media_file_size(f),
 		.sector_bytes = 2048,
 		.has_subcodes = SUBCODES_NONE,
 		.need_swap = 0,
@@ -686,7 +686,7 @@ void cdimage_serialize(system_media *media, serialize_buffer *buf)
 	save_int32(buf, media->cur_track);
 	save_int32(buf, media->cur_sector);
 	if (media->cur_track < media->num_tracks && media->tracks[media->cur_track].f) {
-		save_int32(buf, ftell(media->tracks[media->cur_track].f));
+		save_int32(buf, media_ftell(media->tracks[media->cur_track].f));
 	} else {
 		save_int32(buf, 0);
 	}
@@ -709,7 +709,7 @@ void cdimage_deserialize(deserialize_buffer *buf, void *vmedia)
 	media->cur_sector = load_int32(buf);
 	uint32_t seekpos = load_int32(buf);
 	if (media->cur_track < media->num_tracks && media->tracks[media->cur_track].f) {
-		fseek(media->tracks[media->cur_track].f, seekpos, SEEK_SET);
+		media_fseek(media->tracks[media->cur_track].f, seekpos, SEEK_SET);
 	}
 	media->in_fake_pregap = load_int8(buf);
 	media->byte_storage[0] = load_int8(buf);

--- a/chdimage.c
+++ b/chdimage.c
@@ -202,13 +202,67 @@ static uint8_t read_track_metadata(chd_file *chd, uint32_t index, track_info *tr
 	return 1;
 }
 
+//libchdr can be handed either a path or a core_file of callbacks. The libretro
+//build takes the second route so a CHD behind the frontend's VFS - an Android
+//content:// URI, a file on an SMB share - opens like any other. media_file is
+//plain stdio outside that build, so this is the same code either way.
+static uint64_t chd_media_fsize(struct chd_core_file *file)
+{
+	long size = media_file_size((media_file *)file->argp);
+	return size < 0 ? (uint64_t)-1 : (uint64_t)size;
+}
+
+static size_t chd_media_fread(void *dst, size_t size, size_t count, struct chd_core_file *file)
+{
+	return media_fread(dst, size, count, (media_file *)file->argp);
+}
+
+static int chd_media_fclose(struct chd_core_file *file)
+{
+	int ret = media_fclose((media_file *)file->argp);
+	free(file);
+	return ret;
+}
+
+static int chd_media_fseek(struct chd_core_file *file, int64_t offset, int whence)
+{
+	return media_fseek((media_file *)file->argp, offset, whence);
+}
+
+//Owns the media_file: a successful chd_open_core_file() hands the lifetime to
+//libchdr, which closes it through the callback above.
+static core_file *chd_media_open(const char *path)
+{
+	media_file *f = media_fopen(path, "rb");
+	if (!f) {
+		return NULL;
+	}
+	core_file *cf = calloc(1, sizeof(core_file));
+	if (!cf) {
+		media_fclose(f);
+		return NULL;
+	}
+	cf->argp = f;
+	cf->fsize = chd_media_fsize;
+	cf->fread = chd_media_fread;
+	cf->fclose = chd_media_fclose;
+	cf->fseek = chd_media_fseek;
+	return cf;
+}
+
 //chd_open() fails on a zstd compressed CHD because the codec is stubbed out (see
 //libchdr/zstd.h), and a failed open says nothing about why. The header parses
 //without any codec, so ask it directly.
 static uint8_t uses_zstd(const char *path)
 {
 	chd_header header;
-	if (chd_read_header(path, &header) != CHDERR_NONE) {
+	core_file *cf = chd_media_open(path);
+	if (!cf) {
+		return 0;
+	}
+	chd_error err = chd_read_header_core_file(cf, &header);
+	core_fclose(cf);
+	if (err != CHDERR_NONE) {
 		return 0;
 	}
 	for (int i = 0; i < 4; i++)
@@ -223,8 +277,12 @@ static uint8_t uses_zstd(const char *path)
 uint8_t parse_chd(system_media *media)
 {
 	chd_file *chd = NULL;
-	chd_error err = chd_open(media->orig_path, CHD_OPEN_READ, NULL, &chd);
+	core_file *cf = chd_media_open(media->orig_path);
+	chd_error err = cf ? chd_open_core_file(cf, CHD_OPEN_READ, NULL, &chd) : CHDERR_FILE_NOT_FOUND;
 	if (err != CHDERR_NONE) {
+		//libchdr closes the core_file for us here: its failure path runs
+		//chd_close(), which calls the fclose callback. The one exception is
+		//failing to allocate its own handle, an OOM path not worth unwinding.
 		//The one codec this build leaves out is the one worth naming, since the
 		//file is perfectly good and chdman can rewrite it with another.
 		if (uses_zstd(media->orig_path)) {

--- a/coleco.c
+++ b/coleco.c
@@ -9,6 +9,7 @@
 #include "debug.h"
 #include "bindings.h"
 #include "saves.h"
+#include "media_file.h"
 
 #ifdef NEW_Z80
 #define Z80_CYCLE cycles
@@ -482,11 +483,11 @@ coleco_context *alloc_configure_coleco(system_media *media)
 {
 	coleco_context *coleco = calloc(1, sizeof(coleco_context));
 	char *bios_path = tern_find_path_default(config, "system\0coleco_bios_path\0", (tern_val){.ptrval = "colecovision_bios.col"}, TVAL_PTR).ptrval;
-	if (is_absolute_path(bios_path)) {
-		FILE *f = fopen(bios_path, "rb");
+	if (media_path_is_external(bios_path)) {
+		media_file *f = media_fopen(bios_path, "rb");
 		if (f) {
-			fread(coleco->bios, 1, sizeof(coleco->bios), f);
-			fclose(f);
+			media_fread(coleco->bios, 1, sizeof(coleco->bios), f);
+			media_fclose(f);
 		} else {
 			warning("Failed to open Colecovision BIOS from %s\n", bios_path);
 		}

--- a/flac.c
+++ b/flac.c
@@ -24,7 +24,7 @@ static uint32_t tell_buffer(flac_file *f)
 
 static uint8_t read_byte_file(flac_file *f)
 {
-	int result = fgetc(f->read_data);
+	int result = media_fgetc(f->read_data);
 	if (result == EOF) {
 		return 0;
 	}
@@ -33,12 +33,12 @@ static uint8_t read_byte_file(flac_file *f)
 
 static void seek_file(flac_file *f, uint32_t offset, uint8_t relative)
 {
-	fseek(f->read_data, offset, relative ? SEEK_CUR : SEEK_SET);
+	media_fseek(f->read_data, offset, relative ? SEEK_CUR : SEEK_SET);
 }
 
 static uint32_t tell_file(flac_file *f)
 {
-	return ftell(f->read_data);
+	return media_ftell(f->read_data);
 }
 
 static void read_chars(flac_file *f, char *dest, uint32_t count)
@@ -199,7 +199,7 @@ flac_file *flac_file_from_buffer(void *buffer, uint32_t size)
 	return NULL;
 }
 
-flac_file *flac_file_from_file(FILE *file)
+flac_file *flac_file_from_file(media_file *file)
 {
 	flac_file *f = calloc(1, sizeof(flac_file));
 	f->read_data = file;

--- a/flac.h
+++ b/flac.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include "media_file.h"
 
 typedef struct flac_file flac_file;
 
@@ -52,7 +53,7 @@ struct flac_file {
 };
 
 flac_file *flac_file_from_buffer(void *buffer, uint32_t size);
-flac_file *flac_file_from_file(FILE *file);
+flac_file *flac_file_from_file(media_file *file);
 uint8_t flac_get_sample(flac_file *f, int16_t *out, uint8_t desired_channels);
 void flac_seek(flac_file *f, uint64_t sample_number);
 

--- a/laseractive.c
+++ b/laseractive.c
@@ -8,6 +8,7 @@
 #include "blastem.h"
 #include "paths.h"
 #include "debug.h"
+#include "media_file.h"
 
 static void laseractive_next_shake(upd78k2_context *upd, uint8_t port_bit, uint32_t cycle)
 {
@@ -502,18 +503,18 @@ laseractive *alloc_laseractive(system_media *media, uint32_t opts)
 	la->header.info.name = strdup(media->name);
 	char *upd_rom_path = tern_find_path_default(config, "system\0laseractive_upd_rom\0", (tern_val){.ptrval = "laseractive_dyw_1322a.bin"}, TVAL_PTR).ptrval;
 	uint32_t firmware_size;
-	if (is_absolute_path(upd_rom_path)) {
-		FILE *f = fopen(upd_rom_path, "rb");
+	if (media_path_is_external(upd_rom_path)) {
+		media_file *f = media_fopen(upd_rom_path, "rb");
 		if (f) {
-			long to_read = file_size(f);
+			long to_read = media_file_size(f);
 			if (to_read > sizeof(la->upd_rom)) {
 				to_read = sizeof(la->upd_rom);
 			}
-			firmware_size = fread(la->upd_rom, 1, to_read, f);
+			firmware_size = media_fread(la->upd_rom, 1, to_read, f);
 			if (!firmware_size) {
 				warning("Failed to read from %s\n", upd_rom_path);
 			}
-			fclose(f);
+			media_fclose(f);
 		} else {
 			warning("Failed to open %s\n", upd_rom_path);
 		}

--- a/libblastem.c
+++ b/libblastem.c
@@ -12,6 +12,7 @@
 #include "genesis.h"
 #include "sms.h"
 #include "cdimage.h"
+#include "vfs_file.h"
 
 tern_node *config;
 
@@ -101,6 +102,17 @@ RETRO_API void retro_set_environment(retro_environment_t re)
 	};
 	vars[0].value = system_type_desc;
 	re(RETRO_ENVIRONMENT_SET_VARIABLES, (void *)vars);
+
+	//Everything we open by name - CD images and each track file a cue sheet
+	//points at, compressed ROMs, the Sega CD and 32X BIOS - goes through the
+	//frontend when it offers this, so those paths work when they are Android
+	//content:// URIs or live on an SMB share. Version 1 is all we need: open,
+	//read, seek, tell, size and close. Nothing happens if it is unavailable,
+	//vfs_file falls back to stdio.
+	struct retro_vfs_interface_info vfs_info = { .required_interface_version = 1, .iface = NULL };
+	if (re(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_info) && vfs_info.iface) {
+		vfs_file_set_interface(vfs_info.iface, vfs_info.required_interface_version);
+	}
 
 	const char *system_dir = NULL;
 	re(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);

--- a/media_file.h
+++ b/media_file.h
@@ -1,0 +1,49 @@
+#ifndef MEDIA_FILE_H_
+#define MEDIA_FILE_H_
+
+/*
+ How a CD image, one of the track files a cue sheet names, or a BIOS gets read.
+
+ Plain stdio everywhere except the libretro build, which routes it through the
+ frontend's VFS so paths only the frontend can open - Android content:// URIs
+ from the Storage Access Framework, files on an SMB share - work too. See
+ vfs_file.h; with no VFS interface on offer that layer is stdio again, so this
+ indirection costs nothing.
+*/
+
+#include <stdio.h>
+
+#ifdef IS_LIB
+
+#include "vfs_file.h"
+
+typedef vfs_file media_file;
+#define media_fopen     vfs_fopen
+#define media_fread     vfs_fread
+#define media_fseek     vfs_fseek
+#define media_ftell     vfs_ftell
+#define media_fgetc     vfs_fgetc
+#define media_fclose    vfs_fclose
+#define media_file_size vfs_file_size
+#define media_path_is_external vfs_path_is_external
+
+#else
+
+typedef FILE media_file;
+#ifdef __ANDROID__
+FILE* fopen_wrapper(const char *path, const char *mode);
+#define media_fopen fopen_wrapper
+#else
+#define media_fopen fopen
+#endif
+#define media_fread     fread
+#define media_fseek     fseek
+#define media_ftell     ftell
+#define media_fgetc     fgetc
+#define media_fclose    fclose
+#define media_file_size file_size
+#define media_path_is_external(path) is_absolute_path(path)
+
+#endif //IS_LIB
+
+#endif //MEDIA_FILE_H_

--- a/segacd.c
+++ b/segacd.c
@@ -8,6 +8,7 @@
 #include "gdb_remote.h"
 #include "blastem.h"
 #include "cdimage.h"
+#include "media_file.h"
 
 #ifdef DO_DEBUG_PRINT
 #define dprintf printf
@@ -1605,17 +1606,17 @@ segacd_context *alloc_configure_segacd(system_media *media, uint32_t opts, uint8
 		key = "system\0scd_bios_us\0";
 	}
 	char *bios_path = tern_find_path_default(config, key, (tern_val){.ptrval = "cdbios.bin"}, TVAL_PTR).ptrval;
-	if (is_absolute_path(bios_path)) {
-		FILE *f = fopen(bios_path, "rb");
+	if (media_path_is_external(bios_path)) {
+		media_file *f = media_fopen(bios_path, "rb");
 		if (f) {
-			long to_read = file_size(f);
+			long to_read = media_file_size(f);
 			cd->rom = malloc(to_read);
-			firmware_size = fread(cd->rom, 1, to_read, f);
+			firmware_size = media_fread(cd->rom, 1, to_read, f);
 			if (!firmware_size) {
 				free(cd->rom);
 				cd->rom = NULL;
 			}
-			fclose(f);
+			media_fclose(f);
 		}
 	} else {
 		cd->rom = (uint16_t *)read_bundled_file(bios_path, &firmware_size);

--- a/system.c
+++ b/system.c
@@ -18,7 +18,19 @@
 #define SMD_MAGIC3 0xBB
 #define SMD_BLOCK_SIZE 0x4000
 
-#ifdef DISABLE_ZLIB
+#ifdef IS_LIB
+//The frontend may hand us a path only it can open - an Android content:// URI,
+//a file on an SMB share - so reads go through its VFS when it offers one. That
+//layer inflates gzipped files as well, which is what gzopen() was doing here.
+#include "vfs_file.h"
+#define ROMFILE vfs_file*
+#define romopen vfs_fopen
+#define romread vfs_fread
+#define romseek vfs_fseek
+#define romgetc vfs_fgetc
+#define romclose vfs_fclose
+#define gzdirect vfs_fdirect
+#elif defined(DISABLE_ZLIB)
 #define ROMFILE FILE*
 #ifdef __ANDROID__
 #define romopen fopen_wrapper

--- a/system.h
+++ b/system.h
@@ -3,6 +3,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "media_file.h"
 #include "flac.h"
 #include "zip.h"
 
@@ -68,7 +69,7 @@ enum {
 };
 
 typedef struct {
-	FILE       *f;
+	media_file *f;
 	flac_file  *flac;
 	uint32_t   file_offset;
 	uint32_t   fake_pregap;

--- a/vfs_file.c
+++ b/vfs_file.c
@@ -1,0 +1,230 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "vfs_file.h"
+#include "libretro.h"
+#include "paths.h"
+#ifndef DISABLE_ZLIB
+#include "zlib/zlib.h"
+#endif
+
+static struct retro_vfs_interface *vfs;
+static uint32_t vfs_version;
+
+void vfs_file_set_interface(struct retro_vfs_interface *iface, uint32_t version)
+{
+	vfs = iface;
+	vfs_version = version;
+}
+
+struct vfs_file {
+	struct retro_vfs_file_handle *vf;	//VFS handle, when the frontend gave us one
+	FILE *fp;							//plain stdio otherwise
+	uint8_t *mem;						//inflated contents, for a gzipped file
+	long mem_size;
+	long mem_pos;
+};
+
+#ifndef DISABLE_ZLIB
+//Read the whole file and inflate it. Returns 0 and leaves the file positioned
+//at the start again if it turns out not to be usable gzip data, so the caller
+//can carry on reading it as-is.
+static int slurp_gzip(vfs_file *f)
+{
+	long size = vfs_file_size(f);
+	if (size <= 0) {
+		return 0;
+	}
+	uint8_t *raw = malloc(size);
+	if (!raw) {
+		return 0;
+	}
+	vfs_fseek(f, 0, SEEK_SET);
+	if (vfs_fread(raw, 1, size, f) != (size_t)size) {
+		free(raw);
+		vfs_fseek(f, 0, SEEK_SET);
+		return 0;
+	}
+
+	z_stream z;
+	memset(&z, 0, sizeof(z));
+	//16 + MAX_WBITS: decode a gzip wrapper rather than a raw zlib stream
+	if (inflateInit2(&z, 16 + MAX_WBITS) != Z_OK) {
+		free(raw);
+		vfs_fseek(f, 0, SEEK_SET);
+		return 0;
+	}
+	z.next_in = raw;
+	z.avail_in = size;
+
+	long cap = size * 4 + 4096;
+	uint8_t *out = malloc(cap);
+	long have = 0;
+	int status;
+	do {
+		if (have == cap) {
+			cap *= 2;
+			uint8_t *bigger = realloc(out, cap);
+			if (!bigger) {
+				free(out);
+				out = NULL;
+				break;
+			}
+			out = bigger;
+		}
+		z.next_out = out + have;
+		z.avail_out = cap - have;
+		status = inflate(&z, Z_NO_FLUSH);
+		have = cap - z.avail_out;
+	} while (status == Z_OK && out);
+	inflateEnd(&z);
+	free(raw);
+
+	//Only a complete stream counts. Anything else - a truncated file, or data
+	//that merely happens to start with the gzip magic - is read as-is instead.
+	if (!out || status != Z_STREAM_END || !have) {
+		free(out);
+		vfs_fseek(f, 0, SEEK_SET);
+		return 0;
+	}
+	f->mem = out;
+	f->mem_size = have;
+	f->mem_pos = 0;
+	return 1;
+}
+#endif //DISABLE_ZLIB
+
+//mode is the stdio one and only reaches the stdio path; media is opened for
+//reading only, which is all RETRO_VFS_FILE_ACCESS_READ offers.
+vfs_file *vfs_fopen(const char *path, const char *mode)
+{
+	vfs_file *f = calloc(1, sizeof(vfs_file));
+	if (!f) {
+		return NULL;
+	}
+	if (vfs) {
+		f->vf = vfs->open(path, RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+	} else {
+		f->fp = fopen(path, mode);
+	}
+	if (!f->vf && !f->fp) {
+		free(f);
+		return NULL;
+	}
+#ifndef DISABLE_ZLIB
+	uint8_t magic[2];
+	if (vfs_fread(magic, 1, sizeof(magic), f) == sizeof(magic) && magic[0] == 0x1F && magic[1] == 0x8B) {
+		slurp_gzip(f);
+	}
+	if (!f->mem) {
+		vfs_fseek(f, 0, SEEK_SET);
+	}
+#endif
+	return f;
+}
+
+size_t vfs_fread(void *dst, size_t size, size_t count, vfs_file *f)
+{
+	size_t bytes = size * count;
+	if (!bytes) {
+		return 0;
+	}
+	if (f->mem) {
+		long left = f->mem_size - f->mem_pos;
+		if (left <= 0) {
+			return 0;
+		}
+		if (bytes > (size_t)left) {
+			bytes = left;
+		}
+		memcpy(dst, f->mem + f->mem_pos, bytes);
+		f->mem_pos += bytes;
+		return bytes / size;
+	}
+	if (f->vf) {
+		int64_t got = vfs->read(f->vf, dst, bytes);
+		return got > 0 ? (size_t)got / size : 0;
+	}
+	return fread(dst, size, count, f->fp);
+}
+
+int vfs_fseek(vfs_file *f, long offset, int whence)
+{
+	if (f->mem) {
+		long base = whence == SEEK_CUR ? f->mem_pos : (whence == SEEK_END ? f->mem_size : 0);
+		long pos = base + offset;
+		if (pos < 0 || pos > f->mem_size) {
+			return -1;
+		}
+		f->mem_pos = pos;
+		return 0;
+	}
+	if (f->vf) {
+		int seek_pos = whence == SEEK_CUR ? RETRO_VFS_SEEK_POSITION_CURRENT
+		             : (whence == SEEK_END ? RETRO_VFS_SEEK_POSITION_END : RETRO_VFS_SEEK_POSITION_START);
+		return vfs->seek(f->vf, offset, seek_pos) < 0 ? -1 : 0;
+	}
+	return fseek(f->fp, offset, whence);
+}
+
+long vfs_ftell(vfs_file *f)
+{
+	if (f->mem) {
+		return f->mem_pos;
+	}
+	if (f->vf) {
+		return (long)vfs->tell(f->vf);
+	}
+	return ftell(f->fp);
+}
+
+int vfs_fgetc(vfs_file *f)
+{
+	uint8_t byte;
+	return vfs_fread(&byte, 1, 1, f) == 1 ? byte : -1;
+}
+
+int vfs_fclose(vfs_file *f)
+{
+	int ret = 0;
+	if (f->vf) {
+		ret = vfs->close(f->vf);
+	} else if (f->fp) {
+		ret = fclose(f->fp);
+	}
+	free(f->mem);
+	free(f);
+	return ret;
+}
+
+long vfs_file_size(vfs_file *f)
+{
+	if (f->mem) {
+		return f->mem_size;
+	}
+	if (f->vf) {
+		return (long)vfs->size(f->vf);
+	}
+	long cur = ftell(f->fp);
+	fseek(f->fp, 0, SEEK_END);
+	long size = ftell(f->fp);
+	fseek(f->fp, cur, SEEK_SET);
+	return size;
+}
+
+int vfs_fdirect(vfs_file *f)
+{
+	return f->mem == NULL;
+}
+
+//Whether a path names something outside the emulator's own directory. A VFS
+//path does not have to look absolute to be one: Android hands out content://
+//URIs and an SMB share is smb://, and treating those as relative sends the
+//caller to read_bundled_file(), which in a libretro build finds nothing.
+int vfs_path_is_external(const char *path)
+{
+	if (is_absolute_path((char *)path)) {
+		return 1;
+	}
+	return vfs && strstr(path, "://") != NULL;
+}

--- a/vfs_file.h
+++ b/vfs_file.h
@@ -1,0 +1,50 @@
+#ifndef VFS_FILE_H_
+#define VFS_FILE_H_
+
+/*
+ A thin "read a media file" layer for the libretro build.
+
+ The frontend may hand us paths we cannot open ourselves: Android content://
+ URIs from the Storage Access Framework, SMB shares, or anything else behind
+ RETRO_ENVIRONMENT_GET_VFS_INTERFACE. ROMs listed in the content info override
+ arrive in memory and never reach this code, but CD images (cue/toc/iso/chd,
+ plus every track file a cue sheet names), compressed ROMs and the Sega CD /
+ 32X BIOS are all opened by us, by path.
+
+ So everything that opens a media file by name goes through here instead of
+ stdio. With no VFS interface offered - an older frontend, or the standalone
+ emulator - it is plain stdio, which is also why blastem's own code outside
+ the libretro build is left alone.
+
+ Gzip is handled here too. The stdio path used to get it from gzopen(), and
+ that takes a filename, so it cannot be pointed at a VFS handle; a gzipped
+ file is instead read through the VFS and inflated into memory up front.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct vfs_file vfs_file;
+
+struct retro_vfs_interface;
+
+//Called once from retro_set_environment. iface may be NULL, which keeps
+//everything on stdio.
+void vfs_file_set_interface(struct retro_vfs_interface *iface, uint32_t version);
+
+vfs_file *vfs_fopen(const char *path, const char *mode);
+size_t vfs_fread(void *dst, size_t size, size_t count, vfs_file *f);
+int vfs_fseek(vfs_file *f, long offset, int whence);
+long vfs_ftell(vfs_file *f);
+int vfs_fgetc(vfs_file *f);
+int vfs_fclose(vfs_file *f);
+//Size of the file in bytes, or of the inflated data for a gzipped one.
+long vfs_file_size(vfs_file *f);
+//Whether a path points outside the emulator directory - absolute, or a URI
+//the frontend's VFS can resolve.
+int vfs_path_is_external(const char *path);
+//Whether the file is being read as-is, i.e. gzip did not kick in. Mirrors
+//zlib's gzdirect(), which the ROM loader uses to spot a gzipped ROM.
+int vfs_fdirect(vfs_file *f);
+
+#endif //VFS_FILE_H_

--- a/wave.c
+++ b/wave.c
@@ -28,10 +28,10 @@ int wave_init(FILE * f, uint32_t sample_rate, uint16_t bits_per_sample, uint16_t
 	return fwrite(&header, 1, sizeof(header) - sizeof(header.data_offset), f) == sizeof(header);
 }
 
-uint8_t wave_read_header(FILE *f, wave_header *header)
+uint8_t wave_read_header(media_file *f, wave_header *header)
 {
 	size_t initial_read = offsetof(wave_header, data_header);
-	if (fread(header, 1, initial_read, f) != initial_read) {
+	if (media_fread(header, 1, initial_read, f) != initial_read) {
 		return 0;
 	}
 	if (memcmp(header->chunk.id, "RIFF", 4)) {
@@ -49,17 +49,17 @@ uint8_t wave_read_header(FILE *f, wave_header *header)
 	if (header->format_header.size < offsetof(wave_header, data_header) - sizeof(header->chunk) - sizeof(header->format_header)) {
 		return 0;
 	}
-	fseek(f, header->format_header.size + sizeof(header->chunk) + sizeof(header->format_header), SEEK_SET);
+	media_fseek(f, header->format_header.size + sizeof(header->chunk) + sizeof(header->format_header), SEEK_SET);
 	for (;;)
 	{
-		if (fread(&header->data_header, 1, sizeof(header->data_header), f) != sizeof(header->data_header)) {
+		if (media_fread(&header->data_header, 1, sizeof(header->data_header), f) != sizeof(header->data_header)) {
 			return 0;
 		}
 		if (!memcmp(header->data_header.id, "data", 4)) {
-			header->data_offset = ftell(f);
+			header->data_offset = media_ftell(f);
 			return 1;
 		}
-		fseek(f, header->data_header.size, SEEK_CUR);
+		media_fseek(f, header->data_header.size, SEEK_CUR);
 	}
 }
 

--- a/wave.h
+++ b/wave.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include "media_file.h"
 
 #pragma pack(push, 1)
 
@@ -38,7 +39,7 @@ typedef struct {
 #pragma pack(pop)
 
 int wave_init(FILE * f, uint32_t sample_rate, uint16_t bits_per_sample, uint16_t num_channels);
-uint8_t wave_read_header(FILE *f, wave_header *header);
+uint8_t wave_read_header(media_file *f, wave_header *header);
 int wave_finalize(FILE * f);
 
 #endif //WAVE_H_


### PR DESCRIPTION
Closes #56.

On Android the frontend hands out Storage Access Framework `content://` URIs, and an SMB share is `smb://`; `fopen()` can do nothing with either. Plain ROMs already arrive in memory through the content info override, so what was unreachable is everything the core opens by name itself: CD images (`cue`/`toc`/`iso`/`chd`) and every track file a cue sheet points at, compressed ROMs, and the Sega CD, 32X, Colecovision and LaserActive BIOS.

`vfs_file.c` talks to `RETRO_ENVIRONMENT_GET_VFS_INTERFACE` and `media_file.h` selects it for the libretro build alone; with no interface on offer, or in the standalone emulator, it compiles down to the same stdio calls as before. Two things needed more than a rename: gzip used to come from `gzopen()`, which takes a filename and cannot be pointed at a VFS handle, so a gzipped file is read through the VFS and inflated in memory (falling back to reading it as-is unless a complete stream comes out); and CHDs go through `chd_open_core_file()` with a bridge to the same layer instead of `chd_open()`, which opens the path itself. `is_absolute_path()` also had to be relaxed for the BIOS lookups — a URI does not look absolute to it, so the path fell through to `read_bundled_file()`, which in a libretro build never finds anything.

Tested with a harness that offers the core a VFS whose paths carry a scheme nothing else can resolve, so a successful load proves the callbacks were used: ROM, gzipped ROM, cue plus its track file, iso and the BIOS all load through it, an invalid CHD fails cleanly with the existing message, and with the interface withheld everything still loads over stdio. The gzipped and uncompressed ROM produce identical framebuffers after 30 frames. Standalone was checked by type-checking the shared translation units without `IS_LIB`; `system.c`, `coleco.c` and `laseractive.c` need SDL/GLES headers I don't have here, and their changes are either inside `#ifdef IS_LIB` or macros expanding to the exact stdio calls that were there before.