### PR TITLE
libretro: crop overscan on the core's own say-so

### DIFF
--- a/libblastem.c
+++ b/libblastem.c
@@ -266,22 +266,23 @@ static const core_option core_options[] = {
 	},
 	{
 		"blastem_overscan_top", "Overscan Cropped, Top",
-		"Lines cropped off the top of the picture. Auto follows the frontend's own crop overscan setting.",
+		"Lines cropped off the top of the picture. Auto crops the region's overscan area, which in some games also "
+		"shaves a frame off the input lag: the picture is finished before the game reads the pad.",
 		"video", NULL, overscan_values
 	},
 	{
 		"blastem_overscan_bottom", "Overscan Cropped, Bottom",
-		"Lines cropped off the bottom of the picture. Auto follows the frontend's own crop overscan setting.",
+		"Lines cropped off the bottom of the picture. Auto crops the region's overscan area.",
 		"video", NULL, overscan_values
 	},
 	{
 		"blastem_overscan_left", "Overscan Cropped, Left",
-		"Columns cropped off the left of the picture. Auto follows the frontend's own crop overscan setting.",
+		"Columns cropped off the left of the picture. Auto crops the region's overscan area.",
 		"video", NULL, overscan_values
 	},
 	{
 		"blastem_overscan_right", "Overscan Cropped, Right",
-		"Columns cropped off the right of the picture. Auto follows the frontend's own crop overscan setting.",
+		"Columns cropped off the right of the picture. Auto crops the region's overscan area.",
 		"video", NULL, overscan_values
 	}
 };
@@ -632,25 +633,22 @@ static void override_overscan(const char *key, uint32_t *dst)
 	}
 }
 
+//What "Auto" crops: the borders a TV of the region would have hidden anyway.
+//RETRO_ENVIRONMENT_GET_OVERSCAN, which used to decide this, is deprecated and a
+//frontend may stop answering it at all, so the core no longer asks - the option
+//alone says what to crop, and 0 turns cropping off.
 static void update_overscan(void)
 {
-	uint8_t overscan;
-	retro_environment(RETRO_ENVIRONMENT_GET_OVERSCAN, &overscan);
-	if (overscan) {
-		overscan_top = overscan_bot = overscan_left = overscan_right = 0;
+	if (video_standard == VID_NTSC) {
+		overscan_top = 11;
+		overscan_bot = 8;
 	} else {
-		if (video_standard == VID_NTSC) {
-			overscan_top = 11;
-			overscan_bot = 8;
-			overscan_left = 13;
-			overscan_right = 14;
-		} else {
-			overscan_top = 30;
-			overscan_bot = 24;
-			overscan_left = 13;
-			overscan_right = 14;
-		}
+		overscan_top = 30;
+		overscan_bot = 24;
 	}
+	overscan_left = 13;
+	overscan_right = 14;
+
 	//Unlike the rest, cropping is this file's own doing rather than something the
 	//emulator reads out of the config tree, so it can follow the option as soon
 	//as it changes.


### PR DESCRIPTION
Fixes #62.

`Auto` cropping only cropped anything when the frontend answered `RETRO_ENVIRONMENT_GET_OVERSCAN` with "don't use overscan" — that is, when RetroArch's own *Crop Overscan* setting was on. That setting is deprecated and may be removed, and a frontend that stops answering the call leaves the core showing the full borders with no way to ask for the cropped picture short of typing the numbers in by hand.

So the core stops asking. `Auto` now means the region's overscan area — the borders a TV would have hidden — and an explicit `0` means no cropping, which is what the frontend's setting used to be for. `auto` being the default value, the core crops out of the box now, the way Genesis Plus GX does.

On NTSC the auto top crop is exactly `BORDER_TOP_V28`, so the top border ends up fully cropped and the VDP pushes the finished frame at the start of vblank rather than after the border lines. In games that read the pad in between, that is a frame less of input lag; the top option's sublabel says so.

### Tested

Sonic 1 (NTSC) through a small libretro harness that answers `GET_OVERSCAN` either way and hands the core whatever crop option value is being tested:

| frontend Crop Overscan | option | before | after |
| --- | --- | --- | --- |
| off (`GET_OVERSCAN` -> true) | `auto` | 347x243 | **320x224** |
| on (`GET_OVERSCAN` -> false) | `auto` | 320x224 | 320x224 |
| off | `0` | 347x243 | 347x243 |
| off | `8` | - | 331x227 |

The second row is the path that shipped, and it is unchanged; the first is the one the issue is about. The core no longer issues `GET_OVERSCAN` at all.