### PR TITLE
libretro: build an arm64 core on Apple Silicon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
 
+  # MacOS ARM64
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-arm64.yml'
+
   ################################## CELLULAR ################################
   #
   ################################## CONSOLES ################################
@@ -88,4 +92,10 @@ libretro-build-linux-aarch64:
 libretro-build-osx-x64:
   extends:
     - .libretro-osx-x64-make-10-7
+    - .core-defs
+
+# MacOS ARM64
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-arm64-make-default
     - .core-defs

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -27,7 +27,19 @@ else ifneq ($(findstring Darwin,$(UNAME)),)
 	platform = osx
 	OS :=Darwin
 	CC ?=gcc
+#Apple Silicon: the JIT is x86-only, so an arm64 build has to come out as
+#CPU=aarch64, which is what selects the generated 68K/Z80 cores. The buildbot
+#names the architecture in LIBRETRO_APPLE_PLATFORM (arm64-apple-macos10.15);
+#outside CI there is nothing to name it but the machine the build runs on.
+ifneq (,$(findstring arm64,$(LIBRETRO_APPLE_PLATFORM)))
+	ABI := aarch64
+else ifneq (,$(findstring x86_64,$(LIBRETRO_APPLE_PLATFORM)))
 	ABI := x86_64
+else ifneq (,$(filter arm64 aarch64,$(UNAMEM)))
+	ABI := aarch64
+else
+	ABI := x86_64
+endif
 	target = libblastem.dylib
 	libname = blastem_libretro.dylib
 else ifneq ($(findstring Haiku,$(UNAME)),)


### PR DESCRIPTION
Fixes #44.

`Makefile.libretro` pinned every Darwin build to `ABI := x86_64`, which asks for the x86 JIT and `-m64`. On an Apple Silicon mac that is not a build at all, which is why the core has no `osx-arm64` job on the buildbot while the other Mega Drive cores do.

The architecture now comes from `LIBRETRO_APPLE_PLATFORM` - the buildbot's `osx-arm64` job sets it to `arm64-apple-macos10.15` - and falls back to the machine the build runs on, so a native build on either kind of mac does the right thing and the existing `osx-x64` job (Intel runner, variable unset) keeps picking x86_64. `CPU=aarch64` selects the generated 68K and Z80 cores, so this is an interpreter build: slower than the JIT, but it runs, the same way the `linux-aarch64` job already does.

Second commit adds the `osx-arm64` job to `.gitlab-ci.yml`, mirroring what genesis-plus-gx and picodrive have.

### Tested

Built on a GitHub `macos-14` (Apple Silicon) runner with exactly the environment `libretro-infrastructure/ci-templates/osx-arm64.yml` sets:

```
Non-fat file: blastem_libretro.dylib is architecture: arm64
blastem_libretro.dylib:
	libblastem.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.120.2)
```

More of the platform matrix the other Mega Drive cores carry (webOS, dingux/miyoo, emscripten, iOS/tvOS, Android) needs more than an ABI line; those are being checked separately and would come as their own PRs.